### PR TITLE
Update Hugo and add Go setup in theme update workflow

### DIFF
--- a/.github/workflows/update-theme.yml
+++ b/.github/workflows/update-theme.yml
@@ -20,10 +20,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+      - uses: actions/setup-go@v5
         with:
-          hugo-version: 0.123.8
+          go-version: "^1.17.0"
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.125.0"
           extended: true
 
       - name: Update theme


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow for theme updates to include Go setup and modernize the Hugo action and version.

## Key Changes
- Added Go 1.17+ setup step using `actions/setup-go@v5`
- Upgraded Hugo action from `peaceiris/actions-hugo@v2` to `v3`
- Updated Hugo version from 0.123.8 to 0.125.0

## Details
The workflow now explicitly sets up Go before running Hugo, which may be required by the extended Hugo build or theme processing. The Hugo action and version upgrades ensure compatibility with the latest tooling and include bug fixes and improvements from recent releases.

https://claude.ai/code/session_01Kud6opAgGB3g6ZY8YXj3Et